### PR TITLE
Feature/l3 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ View OpenAPI documentation for all routes with Swagger:
 ```
 localhost:3000/swagger/
 ```
+## Database
+```sh
+# running migrations
+npm run db:migrate
+
+# creating new migration
+## install npx globally
+npm i -g knex
+## make new migration with some prefixes
+npx knex migrate:make --knexfile src/lib/db/knexfile.ts attachments-table 
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ View OpenAPI documentation for all routes with Swagger:
 localhost:3000/swagger/
 ```
 ## Database
+> before performing any database interations like clean/migrate make sure you have database running e.g. docker-compose up -d
+> or any local instance if not using docker
 ```sh
 # running migrations
 npm run db:migrate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An open api typescript nodejs/express api service template",
   "main": "src/index.ts",
   "scripts": {

--- a/src/lib/db/migrations/20230313130941_attachments-table.ts
+++ b/src/lib/db/migrations/20230313130941_attachments-table.ts
@@ -1,0 +1,18 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable('attachments', (def) => {
+        def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
+        def.string('filename', 255).notNullable()
+        def.binary('binary_blob').notNullable()
+        def.datetime('created_at').notNullable().defaultTo(knex.fn.now())
+    
+        def.primary(['id'])
+      })
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTable('attachments')
+}
+

--- a/src/lib/db/migrations/20230313130941_attachments-table.ts
+++ b/src/lib/db/migrations/20230313130941_attachments-table.ts
@@ -1,18 +1,20 @@
-import { Knex } from "knex";
+import { Knex } from 'knex'
 
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.createTable('attachments', (def) => {
-        def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
-        def.string('filename', 255).notNullable()
-        def.binary('binary_blob').notNullable()
-        def.datetime('created_at').notNullable().defaultTo(knex.fn.now())
-    
-        def.primary(['id'])
-      })
-}
+  const [extInstalled] = await knex('pg_extension').select('*').where({ extname: 'uuid-ossp' })
 
+  if (!extInstalled) await knex.raw('CREATE EXTENSION "uuid-ossp"')
+
+  await knex.schema.createTable('attachments', (def) => {
+    def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
+    def.string('filename', 255).notNullable()
+    def.binary('binary_blob').notNullable()
+    def.datetime('created_at').notNullable().defaultTo(knex.fn.now())
+
+    def.primary(['id'])
+  })
+}
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.schema.dropTable('attachments')
+  await knex.schema.dropTable('attachments')
 }
-

--- a/src/lib/db/migrations/20230313130941_attachments-table.ts
+++ b/src/lib/db/migrations/20230313130941_attachments-table.ts
@@ -17,4 +17,5 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   await knex.schema.dropTable('attachments')
+  await knex.raw('DROP EXTENSION "uuid-ossp"')
 }


### PR DESCRIPTION
# What
- adding a new database migration `attachments-table`

```sh
dscp-matchmaker-api=# select * from attachments;
 id | filename | binary_blob | created_at 
----+----------+-------------+------------
(0 rows)

dscp-matchmaker-api=# \dt+ attachments
                                        List of relations
 Schema |    Name     | Type  |  Owner   | Persistence | Access method |    Size    | Description 
--------+-------------+-------+----------+-------------+---------------+------------+-------------
 public | attachments | table | postgres | permanent   | heap          | 8192 bytes | 
(1 row)

dscp-matchmaker-api=# \dt+
                                          List of relations
 Schema |      Name       | Type  |  Owner   | Persistence | Access method |    Size    | Description 
--------+-----------------+-------+----------+-------------+---------------+------------+-------------
 public | attachments     | table | postgres | permanent   | heap          | 8192 bytes | 
 public | migrations      | table | postgres | permanent   | heap          | 8192 bytes | 
 public | migrations_lock | table | postgres | permanent   | heap          | 8192 bytes | 
(3 rows)

dscp-matchmaker-api=# 
```