### PR TITLE
Update transaction table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/capacity/index.ts
+++ b/src/controllers/capacity/index.ts
@@ -19,7 +19,7 @@ import { DemandResponse, DemandSubtype, DemandRequest, DemandState } from '../..
 import { UUID } from '../../models/uuid'
 import { BadRequest, NotFound } from '../../lib/error-handler/index'
 import { getMemberByAddress, getMemberBySelf } from '../../lib/services/identity'
-import { TransactionResponse, TransactionState } from '../../models/transaction'
+import { TransactionResponse, TransactionState, TransactionApiType, TransactionType } from '../../models/transaction'
 import { TokenType } from '../../models/tokenType'
 import { runProcess } from '../..//lib/services/dscpApi'
 import { demandCreate } from '../../lib/payload'
@@ -107,7 +107,8 @@ export class CapacityController extends Controller {
     if (capacity.state !== DemandState.created) throw new BadRequest(`Demand must have state: ${DemandState.created}`)
 
     const [transaction] = await this.db.insertTransaction({
-      token_type: TokenType.DEMAND,
+      api_type: TransactionApiType.capacity,
+      transaction_type: TransactionType.creation,
       local_id: capacityId,
       state: TransactionState.submitted,
     })

--- a/src/controllers/match2/index.ts
+++ b/src/controllers/match2/index.ts
@@ -19,7 +19,7 @@ import { BadRequest, NotFound } from '../../lib/error-handler/index'
 import { getMemberByAddress, getMemberBySelf } from '../../lib/services/identity'
 import { Match2Request, Match2Response, Match2State } from '../../models/match2'
 import { UUID } from '../../models/uuid'
-import { TransactionResponse, TransactionState } from '../../models/transaction'
+import { TransactionResponse, TransactionState, TransactionType, TransactionApiType } from '../../models/transaction'
 import { TokenType } from '../../models/tokenType'
 import { observeTokenId } from '../../lib/services/blockchainWatcher'
 import { runProcess } from '../../lib/services/dscpApi'
@@ -115,7 +115,8 @@ export class Match2Controller extends Controller {
     validatePreOnChain(demandB, DemandSubtype.capacity, 'DemandB')
 
     const [transaction] = await this.db.insertTransaction({
-      token_type: TokenType.MATCH2,
+      transaction_type: TransactionType.proposal,
+      api_type: TransactionApiType.match2,
       local_id: match2Id,
       state: TransactionState.submitted,
     })

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -41,7 +41,7 @@ const transactionColumns = [
   'state',
   'local_id AS localId',
   'api_type AS apiType',
-  'transactionType AS transactionType',
+  'transaction_type AS transactionType',
   'created_at AS submittedAt',
   'updated_at AS updatedAt',
 ]

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -40,8 +40,8 @@ const transactionColumns = [
   'id',
   'state',
   'local_id AS localId',
-  'api_type AS api_Type',
-  'transactionType AS transaction_type',
+  'api_type AS apiType',
+  'transactionType AS transactionType',
   'created_at AS submittedAt',
   'updated_at AS updatedAt',
 ]

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -40,7 +40,8 @@ const transactionColumns = [
   'id',
   'state',
   'local_id AS localId',
-  'token_type AS tokenType',
+  'api_type AS api_Type',
+  'transactionType AS transaction_type',
   'created_at AS submittedAt',
   'updated_at AS updatedAt',
 ]

--- a/src/lib/db/migrations/20230329093154_transaction-table-modify-cols.ts
+++ b/src/lib/db/migrations/20230329093154_transaction-table-modify-cols.ts
@@ -10,5 +10,13 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.dropTable('transaction')
+  return knex.schema.table('transaction', function (table) {
+    table.integer('token_id')
+    table.enu('token_type', ['DEMAND', 'MATCH2'], {
+      enumName: 'type',
+      useNative: true,
+    })
+    table.dropColumn('transaction_type')
+    table.dropColumn('api_type')
+  })
 }

--- a/src/lib/db/migrations/20230329093154_transaction-table-modify-cols.ts
+++ b/src/lib/db/migrations/20230329093154_transaction-table-modify-cols.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('transaction', function (table) {
+    table.dropColumn('token_id')
+    table.dropColumn('token_type')
+    table.enu('api_type', ['match2', 'order', 'capacity'], { useNative: true, enumName: 'api_type' })
+    table.enu('transaction_type', ['creation', 'proposal', 'accept'], { useNative: true, enumName: 'transaction_type' })
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('transaction')
+}

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -19,3 +19,15 @@ export interface TransactionResponse {
   submittedAt: Date
   updatedAt: Date
 }
+
+export enum TransactionApiType {
+  match2 = 'match2',
+  order = 'order',
+  capacity = 'capacity',
+}
+
+export enum TransactionType {
+  creation = 'creation',
+  proposal = 'proposal',
+  accept = 'accept',
+}

--- a/test/integration/capacity.test.ts
+++ b/test/integration/capacity.test.ts
@@ -24,9 +24,8 @@ import {
   apiRunProcessMockError,
   demandCreateMockTokenId,
 } from '../helper/mock'
-import { TransactionState } from '../../src/models/transaction'
+import { TransactionState, TransactionApiType, TransactionType } from '../../src/models/transaction'
 import Database from '../../src/lib/db'
-import { TokenType } from '../../src/models/tokenType'
 
 const db = new Database()
 
@@ -112,7 +111,8 @@ describe('capacity', () => {
       expect(response.status).to.equal(200)
       expect(response.body).to.deep.equal({
         id: seededTransactionId,
-        tokenType: TokenType.DEMAND,
+        api_type: TransactionApiType.capacity,
+        transaction_type: TransactionType.creation,
         localId: seededCapacityId,
         state: TransactionState.submitted,
         submittedAt: exampleDate,
@@ -126,7 +126,8 @@ describe('capacity', () => {
       expect(response.body).to.deep.equal([
         {
           id: seededTransactionId,
-          tokenType: TokenType.DEMAND,
+          api_type: TransactionApiType.capacity,
+          transaction_type: TransactionType.creation,
           localId: seededCapacityId,
           state: TransactionState.submitted,
           submittedAt: exampleDate,
@@ -134,7 +135,8 @@ describe('capacity', () => {
         },
         {
           id: seededTransactionId2,
-          tokenType: TokenType.DEMAND,
+          api_type: TransactionApiType.capacity,
+          transaction_type: TransactionType.creation,
           localId: seededCapacityId,
           state: TransactionState.submitted,
           submittedAt: exampleDate,

--- a/test/integration/capacity.test.ts
+++ b/test/integration/capacity.test.ts
@@ -135,8 +135,8 @@ describe('capacity', () => {
         },
         {
           id: seededTransactionId2,
-          api_type: TransactionApiType.capacity,
-          transaction_type: TransactionType.creation,
+          apiType: TransactionApiType.capacity,
+          transactionType: TransactionType.creation,
           localId: seededCapacityId,
           state: TransactionState.submitted,
           submittedAt: exampleDate,

--- a/test/integration/capacity.test.ts
+++ b/test/integration/capacity.test.ts
@@ -111,8 +111,8 @@ describe('capacity', () => {
       expect(response.status).to.equal(200)
       expect(response.body).to.deep.equal({
         id: seededTransactionId,
-        api_type: TransactionApiType.capacity,
-        transaction_type: TransactionType.creation,
+        apiType: TransactionApiType.capacity,
+        transactionType: TransactionType.creation,
         localId: seededCapacityId,
         state: TransactionState.submitted,
         submittedAt: exampleDate,
@@ -126,8 +126,8 @@ describe('capacity', () => {
       expect(response.body).to.deep.equal([
         {
           id: seededTransactionId,
-          api_type: TransactionApiType.capacity,
-          transaction_type: TransactionType.creation,
+          apiType: TransactionApiType.capacity,
+          transactionType: TransactionType.creation,
           localId: seededCapacityId,
           state: TransactionState.submitted,
           submittedAt: exampleDate,

--- a/test/integration/match2.test.ts
+++ b/test/integration/match2.test.ts
@@ -27,7 +27,6 @@ import { selfAlias, identitySelfMock, match2ProposeMock, match2ProposeMockTokenI
 import { Match2State } from '../../src/models/match2'
 import { TransactionState, TransactionApiType, TransactionType } from '../../src/models/transaction'
 import Database from '../../src/lib/db'
-import { TokenType } from '../../src/models/tokenType'
 
 const db = new Database()
 

--- a/test/integration/match2.test.ts
+++ b/test/integration/match2.test.ts
@@ -129,12 +129,13 @@ describe('match2', () => {
       expect(response.status).to.equal(200)
       expect(response.body).to.deep.equal({
         id: seededProposalTransactionId,
-        api_type: TransactionApiType.match2,
-        transaction_type: TransactionType.proposal,
-        local_id: seededMatch2Id,
+        apiType: TransactionApiType.match2,
+        transactionType: TransactionType.proposal,
+        localId: seededMatch2Id,
         state: TransactionState.submitted,
         created_at: exampleDate,
-        updated_at: exampleDate,
+        submittedAt: exampleDate,
+        updatedAt: exampleDate,
       })
     })
 
@@ -144,12 +145,13 @@ describe('match2', () => {
       expect(response.body).to.deep.equal([
         {
           id: seededProposalTransactionId,
-          api_type: TransactionApiType.match2,
-          transaction_type: TransactionType.proposal,
-          local_id: seededMatch2Id,
+          apiType: TransactionApiType.match2,
+          transactionType: TransactionType.proposal,
+          localId: seededMatch2Id,
           state: TransactionState.submitted,
-          created_at: exampleDate,
-          updated_at: exampleDate,
+          submittedAt: exampleDate,
+          createdAt: exampleDate,
+          updatedAt: exampleDate,
         },
       ])
     })

--- a/test/integration/match2.test.ts
+++ b/test/integration/match2.test.ts
@@ -133,7 +133,6 @@ describe('match2', () => {
         transactionType: TransactionType.proposal,
         localId: seededMatch2Id,
         state: TransactionState.submitted,
-        created_at: exampleDate,
         submittedAt: exampleDate,
         updatedAt: exampleDate,
       })
@@ -150,7 +149,6 @@ describe('match2', () => {
           localId: seededMatch2Id,
           state: TransactionState.submitted,
           submittedAt: exampleDate,
-          createdAt: exampleDate,
           updatedAt: exampleDate,
         },
       ])

--- a/test/integration/match2.test.ts
+++ b/test/integration/match2.test.ts
@@ -25,7 +25,7 @@ import {
 
 import { selfAlias, identitySelfMock, match2ProposeMock, match2ProposeMockTokenIds } from '../helper/mock'
 import { Match2State } from '../../src/models/match2'
-import { TransactionState } from '../../src/models/transaction'
+import { TransactionState, TransactionApiType, TransactionType } from '../../src/models/transaction'
 import Database from '../../src/lib/db'
 import { TokenType } from '../../src/models/tokenType'
 
@@ -130,11 +130,12 @@ describe('match2', () => {
       expect(response.status).to.equal(200)
       expect(response.body).to.deep.equal({
         id: seededProposalTransactionId,
-        tokenType: TokenType.MATCH2,
-        localId: seededMatch2Id,
+        api_type: TransactionApiType.match2,
+        transaction_type: TransactionType.proposal,
+        local_id: seededMatch2Id,
         state: TransactionState.submitted,
-        submittedAt: exampleDate,
-        updatedAt: exampleDate,
+        created_at: exampleDate,
+        updated_at: exampleDate,
       })
     })
 
@@ -144,11 +145,12 @@ describe('match2', () => {
       expect(response.body).to.deep.equal([
         {
           id: seededProposalTransactionId,
-          tokenType: TokenType.MATCH2,
-          localId: seededMatch2Id,
+          api_type: TransactionApiType.match2,
+          transaction_type: TransactionType.proposal,
+          local_id: seededMatch2Id,
           state: TransactionState.submitted,
-          submittedAt: exampleDate,
-          updatedAt: exampleDate,
+          created_at: exampleDate,
+          updated_at: exampleDate,
         },
       ])
     })

--- a/test/seeds/index.ts
+++ b/test/seeds/index.ts
@@ -107,7 +107,8 @@ export const seed = async () => {
   await db.transaction().insert([
     {
       id: seededProposalTransactionId,
-      token_type: TokenType.MATCH2,
+      api_type: TransactionApiType.match2,
+      transaction_type: TransactionType.proposal,
       local_id: seededMatch2Id,
       state: TransactionState.submitted,
       created_at: exampleDate,

--- a/test/seeds/index.ts
+++ b/test/seeds/index.ts
@@ -2,7 +2,6 @@ import Database from '../../src/lib/db'
 import { DemandState, DemandSubtype } from '../../src/models/demand'
 import { Match2State } from '../../src/models/match2'
 import { selfAddress } from '../helper/mock'
-import { TokenType } from '../../src/models/tokenType'
 import { TransactionState, TransactionApiType, TransactionType } from '../../src/models/transaction'
 
 const db = new Database().db()

--- a/test/seeds/index.ts
+++ b/test/seeds/index.ts
@@ -3,7 +3,7 @@ import { DemandState, DemandSubtype } from '../../src/models/demand'
 import { Match2State } from '../../src/models/match2'
 import { selfAddress } from '../helper/mock'
 import { TokenType } from '../../src/models/tokenType'
-import { TransactionState } from '../../src/models/transaction'
+import { TransactionState, TransactionApiType, TransactionType } from '../../src/models/transaction'
 
 const db = new Database().db()
 
@@ -59,10 +59,10 @@ export const seed = async () => {
   await db.transaction().insert([
     {
       id: seededTransactionId,
-      token_type: TokenType.DEMAND,
+      api_type: TransactionApiType.capacity,
+      transaction_type: TransactionType.creation,
       local_id: seededCapacityId,
       state: TransactionState.submitted,
-      token_id: 6006,
       created_at: exampleDate,
       updated_at: exampleDate,
     },
@@ -71,10 +71,10 @@ export const seed = async () => {
   await db.transaction().insert([
     {
       id: seededTransactionId2,
-      token_type: TokenType.DEMAND,
+      api_type: TransactionApiType.capacity,
+      transaction_type: TransactionType.creation,
       local_id: seededCapacityId,
       state: TransactionState.submitted,
-      token_id: 7000,
       created_at: exampleDate,
       updated_at: exampleDate,
     },


### PR DESCRIPTION
This migration replaces `token_type` -> `api_type` with options ['match2', 'order', 'capacity] and `transaction_type` options match the route that creates the transaction e.g. creation, proposal, accept

`token_id` column has been removed and all tests updated.

<img width="451" alt="Screenshot 2023-03-29 at 12 21 13" src="https://user-images.githubusercontent.com/35331926/228522445-30c4b4e2-64c2-41ed-a383-a8616bfd2b34.png">
