### PR TITLE
Chore/ipfs upload on attachment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,8 @@
   },
   "rules": {
     "prettier/prettier": "error",
+    "no-unused-vars": ["warn", { "ignoreRestSiblings": true }],
+    "@typescript-eslint/no-unused-vars": ["warn", { "ignoreRestSiblings": true }],
     "no-console": 2
   },
   "overrides": [

--- a/docs/database.md
+++ b/docs/database.md
@@ -16,12 +16,13 @@ The following tables exist in the `matchmaker-api` database.
 
 ### `attachment`
 
-| column        | PostgreSQL type           | nullable |       default        | description                            |
-| :------------ | :------------------------ | :------- | :------------------: | :------------------------------------- |
-| `id`          | `UUID`                    | FALSE    | `uuid_generate_v4()` | Unique identifier for the `attachment` |
-| `filename`    | `CHARACTER VARYING (255)` | FALSE    |          -           | Attachment filename                    |
-| `binary_blob` | `binary`                  | FALSE    |          -           | Attachment file data as binary         |
-| `created_at`  | `dateTime`                | FALSE    |       `now()`        | When the row was first created         |
+| column       | PostgreSQL type           | nullable |       default        | description                            |
+| :----------- | :------------------------ | :------- | :------------------: | :------------------------------------- |
+| `id`         | `UUID`                    | FALSE    | `uuid_generate_v4()` | Unique identifier for the `attachment` |
+| `filename`   | `CHARACTER VARYING (255)` | FALSE    |          -           | Attachment filename                    |
+| `ipfs_hash`  | `CHARACTER VARYING (255)` | FALSE    |          -           | Attachment CID in IPFS                 |
+| `size`       | `BIG INT`                 | TRUE     |          -           | Size of file in bytes if known         |
+| `created_at` | `dateTime`                | FALSE    |       `now()`        | When the row was first created         |
 
 #### Indexes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/capacity/index.ts
+++ b/src/controllers/capacity/index.ts
@@ -43,8 +43,6 @@ export class CapacityController extends Controller {
       port: env.NODE_PORT,
       logger,
       userUri: env.USER_URI,
-      ipfsHost: env.IPFS_HOST,
-      ipfsPort: env.IPFS_PORT,
     })
   }
 

--- a/src/controllers/match2/index.ts
+++ b/src/controllers/match2/index.ts
@@ -44,8 +44,6 @@ export class Match2Controller extends Controller {
       port: env.NODE_PORT,
       logger,
       userUri: env.USER_URI,
-      ipfsHost: env.IPFS_HOST,
-      ipfsPort: env.IPFS_PORT,
     })
   }
 

--- a/src/controllers/order/index.ts
+++ b/src/controllers/order/index.ts
@@ -42,8 +42,6 @@ export class order extends Controller {
       port: env.NODE_PORT,
       logger,
       userUri: env.USER_URI,
-      ipfsHost: env.IPFS_HOST,
-      ipfsPort: env.IPFS_PORT,
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,6 @@ import ChainNode from './lib/chainNode'
     port: env.NODE_PORT,
     logger,
     userUri: env.USER_URI,
-    ipfsHost: env.IPFS_HOST,
-    ipfsPort: env.IPFS_PORT,
   })
 
   if (env.ENABLE_INDEXER) {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -92,6 +92,10 @@ export default class Database {
     return this.db().attachment().where({ id: parametersAttachmentId })
   }
 
+  updateAttachmentSize = async (id: string, size: number) => {
+    return this.db().attachment().update({ size }).where({ id })
+  }
+
   insertDemand = async (capacity: object) => {
     return this.db().demand().insert(capacity).returning('*')
   }

--- a/src/lib/db/migrations/20230419105051_attachment-file-hash.ts
+++ b/src/lib/db/migrations/20230419105051_attachment-file-hash.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex'
+
+export const up = async (knex: Knex): Promise<void> => {
+  await knex.schema.alterTable('attachment', (def) => {
+    def.dropColumn('binary_blob')
+    def.string('ipfs_hash').notNullable()
+    def.bigInteger('size').nullable()
+  })
+}
+
+export const down = async (knex: Knex): Promise<void> => {
+  await knex.schema.alterTable('attachment', (def) => {
+    def.dropColumn('ipfs_hash')
+    def.dropColumn('size')
+    def.binary('binary_blob').notNullable()
+  })
+}

--- a/src/lib/error-handler/index.ts
+++ b/src/lib/error-handler/index.ts
@@ -61,6 +61,7 @@ export const errorHandler = function errorHandler(
 ): ExResponse | void {
   if (err instanceof ValidateError) {
     logger.warn(`Handled Validation Error for ${req.path}: %s`, JSON.stringify(err.fields))
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { status, ...rest } = err
 
     return res.status(422).send({

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,6 +1,11 @@
+import basex from 'base-x'
+
 import { Match2Payload, Match2Response } from '../models/match2'
 import { DemandPayload } from '../models/demand'
 import * as TokenType from '../models/tokenType'
+
+const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const bs58 = basex(BASE58)
 
 export interface Payload {
   process: { id: string; version: number }
@@ -18,7 +23,12 @@ export interface MetadataFile {
   filename: string
 }
 
-export type Metadata = Record<string, { type: string; value: string | MetadataFile | number }>
+export type Metadata = Record<string, { type: string; value: string | number }>
+
+const formatHash = (hash: string) => {
+  const decoded = Buffer.from(bs58.decode(hash))
+  return `0x${decoded.toString('hex').slice(4)}`
+}
 
 export const demandCreate = (demand: DemandPayload): Payload => ({
   process: { id: 'demand-create', version: 1 },
@@ -31,7 +41,7 @@ export const demandCreate = (demand: DemandPayload): Payload => ({
         type: { type: 'LITERAL', value: TokenType.DEMAND },
         state: { type: 'LITERAL', value: 'created' },
         subtype: { type: 'LITERAL', value: demand.subtype },
-        parameters: { type: 'FILE', value: { blob: new Blob([demand.binary_blob]), filename: demand.filename } },
+        parameters: { type: 'FILE', value: formatHash(demand.ipfs_hash) },
       },
     },
   ],

--- a/src/models/attachment.ts
+++ b/src/models/attachment.ts
@@ -18,6 +18,6 @@ export interface Attachment {
    * for json files name will be 'json'
    */
   filename: string | 'json'
-  size: number
+  size?: number
   createdAt: Date
 }

--- a/src/models/demand.ts
+++ b/src/models/demand.ts
@@ -26,7 +26,7 @@ export interface DemandResponse {
 
 export interface DemandPayload extends DemandResponse, Attachment {
   subtype: DemandSubtype
-  binary_blob: Buffer
+  ipfs_hash: string
   latestTokenId: number
   originalTokenId: number
 }

--- a/test/helper/mock.ts
+++ b/test/helper/mock.ts
@@ -1,4 +1,4 @@
-import { MockAgent, setGlobalDispatcher } from 'undici'
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher, Dispatcher } from 'undici'
 import env from '../../src/env'
 
 export const selfAlias = 'test-self'
@@ -6,61 +6,112 @@ export const selfAddress = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 export const notSelfAlias = 'test-not-self'
 export const notSelfAddress = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
 
-const mockAgent = new MockAgent()
-setGlobalDispatcher(mockAgent)
+export function withIdentitySelfMock() {
+  let originalDispatcher: Dispatcher
+  let mockAgent: MockAgent
+  beforeEach(function () {
+    originalDispatcher = getGlobalDispatcher()
+    mockAgent = new MockAgent()
+    setGlobalDispatcher(mockAgent)
+    const mockIdentity = mockAgent.get(`http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}`)
+    mockIdentity
+      .intercept({
+        path: '/v1/self',
+        method: 'GET',
+      })
+      .reply(200, {
+        alias: selfAlias,
+        address: selfAddress,
+      })
+      .persist()
 
-const mockIdentity = mockAgent.get(`http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}`)
-const mockIpfs = mockAgent.get(`http://${env.IPFS_HOST}:${env.IPFS_PORT}`)
+    mockIdentity
+      .intercept({
+        path: `/v1/members/${selfAddress}`,
+        method: 'GET',
+      })
+      .reply(200, {
+        alias: selfAlias,
+        address: selfAddress,
+      })
+      .persist()
 
-export const identitySelfMock = () => {
-  mockIdentity
-    .intercept({
-      path: '/v1/self',
-      method: 'GET',
-    })
-    .reply(200, {
-      alias: selfAlias,
-      address: selfAddress,
-    })
-    .persist()
+    mockIdentity
+      .intercept({
+        path: `/v1/members/${notSelfAddress}`,
+        method: 'GET',
+      })
+      .reply(200, {
+        alias: notSelfAlias,
+        address: notSelfAddress,
+      })
+      .persist()
+  })
 
-  mockIdentity
-    .intercept({
-      path: `/v1/members/${selfAddress}`,
-      method: 'GET',
-    })
-    .reply(200, {
-      alias: selfAlias,
-      address: selfAddress,
-    })
-    .persist()
-
-  mockIdentity
-    .intercept({
-      path: `/v1/members/${notSelfAddress}`,
-      method: 'GET',
-    })
-    .reply(200, {
-      alias: notSelfAlias,
-      address: notSelfAddress,
-    })
-    .persist()
+  afterEach(function () {
+    setGlobalDispatcher(originalDispatcher)
+  })
 }
 
-export const ipfsMock = () => {
-  mockIpfs
-    .intercept({
-      path: '/api/v0/add?cid-version=0&wrap-with-directory=true',
-      method: 'POST',
-    })
-    .reply(200, { Name: '', Hash: 'QmXVStDC6kTpVHY1shgBQmyA4SuSrYnNRnHSak5iB6Eehn', Size: '63052' })
+export const withIpfsMock = (fileContent?: string | object | Buffer) => {
+  let originalDispatcher: Dispatcher
+  let mockAgent: MockAgent
+
+  beforeEach(function () {
+    originalDispatcher = getGlobalDispatcher()
+    mockAgent = new MockAgent()
+    setGlobalDispatcher(mockAgent)
+    const mockIpfs = mockAgent.get(`http://${env.IPFS_HOST}:${env.IPFS_PORT}`)
+
+    mockIpfs
+      .intercept({
+        path: '/api/v0/add?cid-version=0&wrap-with-directory=true',
+        method: 'POST',
+      })
+      .reply(200, { Name: '', Hash: 'QmXVStDC6kTpVHY1shgBQmyA4SuSrYnNRnHSak5iB6Eehn', Size: '63052' })
+
+    mockIpfs
+      .intercept({
+        path: '/api/v0/ls?arg=QmXVStDC6kTpVHY1shgBQmyA4SuSrYnNRnHSak5iB6Eehn',
+        method: 'POST',
+      })
+      .reply(200, {
+        Objects: [{ Links: [{ Hash: 'file_hash', Name: 'test' }] }],
+      })
+    if (fileContent) {
+      mockIpfs
+        .intercept({
+          path: '/api/v0/cat?arg=file_hash',
+          method: 'POST',
+        })
+        .reply(200, fileContent)
+    }
+  })
+
+  afterEach(function () {
+    setGlobalDispatcher(originalDispatcher)
+  })
 }
 
-export const ipfsMockError = () => {
-  mockIpfs
-    .intercept({
-      path: '/api/v0/add?cid-version=0&wrap-with-directory=true',
-      method: 'POST',
-    })
-    .reply(500, 'error')
+export const withIpfsMockError = () => {
+  let originalDispatcher: Dispatcher
+  let mockAgent: MockAgent
+
+  beforeEach(function () {
+    originalDispatcher = getGlobalDispatcher()
+    mockAgent = new MockAgent()
+    setGlobalDispatcher(mockAgent)
+    const mockIpfs = mockAgent.get(`http://${env.IPFS_HOST}:${env.IPFS_PORT}`)
+
+    mockIpfs
+      .intercept({
+        path: '/api/v0/add?cid-version=0&wrap-with-directory=true',
+        method: 'POST',
+      })
+      .reply(500, 'error')
+  })
+
+  afterEach(function () {
+    setGlobalDispatcher(originalDispatcher)
+  })
 }

--- a/test/integration/offchain/capacity.test.ts
+++ b/test/integration/offchain/capacity.test.ts
@@ -16,15 +16,16 @@ import {
   seededCapacityAlreadyAllocated,
 } from '../../seeds'
 
-import { selfAlias, identitySelfMock, ipfsMockError } from '../../helper/mock'
+import { selfAlias, withIdentitySelfMock } from '../../helper/mock'
 
 describe('capacity', () => {
   let app: Express
 
   before(async function () {
     app = await createHttpServer()
-    identitySelfMock()
   })
+
+  withIdentitySelfMock()
 
   beforeEach(async function () {
     await seed()
@@ -155,14 +156,6 @@ describe('capacity', () => {
     it('non-existent Capacity ID should return nothing - 404', async () => {
       const response = await get(app, `/capacity/${nonExistentId}/creation/`)
       expect(response.status).to.equal(404)
-    })
-
-    it('ipfs error - 500', async () => {
-      ipfsMockError()
-
-      const { status, body } = await post(app, `/capacity/${seededCapacityId}/creation`, {})
-      expect(status).to.equal(500)
-      expect(body).to.equal('error')
     })
   })
 })

--- a/test/integration/offchain/match2.test.ts
+++ b/test/integration/offchain/match2.test.ts
@@ -27,15 +27,16 @@ import {
   seededOrderWithTokenId,
 } from '../../seeds'
 
-import { selfAlias, identitySelfMock } from '../../helper/mock'
+import { selfAlias, withIdentitySelfMock } from '../../helper/mock'
 
 describe('match2', () => {
   let app: Express
 
   before(async function () {
     app = await createHttpServer()
-    identitySelfMock()
   })
+
+  withIdentitySelfMock()
 
   beforeEach(async function () {
     await seed()

--- a/test/integration/offchain/order.test.ts
+++ b/test/integration/offchain/order.test.ts
@@ -6,7 +6,7 @@ import createHttpServer from '../../../src/server'
 import { post, get } from '../../helper/routeHelper'
 import { seed, parametersAttachmentId, seededOrderId, seededOrderCreationId, cleanup } from '../../seeds'
 
-import { selfAlias, identitySelfMock } from '../../helper/mock'
+import { selfAlias, withIdentitySelfMock } from '../../helper/mock'
 import Database from '../../../src/lib/db'
 
 const db = new Database()
@@ -17,8 +17,9 @@ describe('order', () => {
 
   before(async function () {
     app = await createHttpServer()
-    identitySelfMock()
   })
+
+  withIdentitySelfMock()
 
   beforeEach(async () => await seed())
 

--- a/test/integration/onchain/chain.test.ts
+++ b/test/integration/onchain/chain.test.ts
@@ -6,7 +6,7 @@ import createHttpServer from '../../../src/server'
 import { post } from '../../helper/routeHelper'
 import { seed, cleanup, seededCapacityId, parametersAttachmentId } from '../../seeds'
 
-import { identitySelfMock, ipfsMock } from '../../helper/mock'
+import { withIdentitySelfMock } from '../../helper/mock'
 import Database from '../../../src/lib/db'
 import ChainNode from '../../../src/lib/chainNode'
 import { logger } from '../../../src/lib/logger'
@@ -20,8 +20,6 @@ const node = new ChainNode({
   port: env.NODE_PORT,
   logger,
   userUri: env.USER_URI,
-  ipfsHost: env.IPFS_HOST,
-  ipfsPort: env.IPFS_PORT,
 })
 
 describe('on-chain', function () {
@@ -30,8 +28,9 @@ describe('on-chain', function () {
 
   before(async function () {
     app = await createHttpServer()
-    identitySelfMock()
   })
+
+  withIdentitySelfMock()
 
   beforeEach(async function () {
     await seed()
@@ -43,7 +42,6 @@ describe('on-chain', function () {
 
   describe('capacity', () => {
     it('should create a capacity on-chain', async () => {
-      ipfsMock()
       const lastTokenId = await node.getLastTokenId()
 
       // submit to chain
@@ -68,7 +66,6 @@ describe('on-chain', function () {
 
   describe('order', () => {
     it('creates an order on chain', async () => {
-      ipfsMock()
       const lastTokenId = await node.getLastTokenId()
 
       const {
@@ -108,7 +105,7 @@ describe('on-chain', function () {
 
     beforeEach(async () => {
       // prepare an unallocated order + capacity + local match2
-      ipfsMock()
+
       const {
         body: { id: orderId },
       } = await post(app, '/order', { parametersAttachmentId })
@@ -116,7 +113,6 @@ describe('on-chain', function () {
         body: { id: orderTransactionId },
       } = await post(app, `/order/${orderId}/creation`, {})
 
-      ipfsMock()
       const {
         body: { id: capacityId },
       } = await post(app, '/capacity', { parametersAttachmentId })

--- a/test/seeds/index.ts
+++ b/test/seeds/index.ts
@@ -50,7 +50,8 @@ export const seed = async () => {
     {
       id: parametersAttachmentId,
       filename: 'test.txt',
-      binary_blob: 9999999,
+      ipfs_hash: 'QmXVStDC6kTpVHY1shgBQmyA4SuSrYnNRnHSak5iB6Eehn',
+      size: 42,
     },
   ])
 


### PR DESCRIPTION
We need to upload on attachment creation rather than on submission so that the db doesn't need to store binary data as this will be unavailabe to the block indexer. Also note size has been made optional to reflect that the indexer will not have this information either but instead it is updated on fetching the resource. I will also try to get this information oportunistically in the indexer but if we don't have it null is better than the indexer failing.