### PR TITLE
Fix invalid OpenApi spec properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/attachment/index.ts
+++ b/src/controllers/attachment/index.ts
@@ -62,7 +62,7 @@ interface DbAttachment extends Omit<Attachment, 'createdAt'> {
 
 @Route('attachment')
 @Tags('attachment')
-@Security('bearerAuth')
+@Security('BearerAuth')
 export class attachment extends Controller {
   log: Logger
   dbClient: Database = new Database()

--- a/src/controllers/capacity/index.ts
+++ b/src/controllers/capacity/index.ts
@@ -28,7 +28,7 @@ import env from '../../env'
 
 @Route('capacity')
 @Tags('capacity')
-@Security('bearerAuth')
+@Security('BearerAuth')
 export class CapacityController extends Controller {
   log: Logger
   db: Database

--- a/src/controllers/match2/index.ts
+++ b/src/controllers/match2/index.ts
@@ -29,7 +29,7 @@ import env from '../../env'
 
 @Route('match2')
 @Tags('match2')
-@Security('bearerAuth')
+@Security('BearerAuth')
 export class Match2Controller extends Controller {
   log: Logger
   db: Database

--- a/src/controllers/order/index.ts
+++ b/src/controllers/order/index.ts
@@ -27,7 +27,7 @@ import env from '../../env'
 
 @Route('order')
 @Tags('order')
-@Security('bearerAuth')
+@Security('BearerAuth')
 export class order extends Controller {
   log: Logger
   db: Database

--- a/src/controllers/transaction/index.ts
+++ b/src/controllers/transaction/index.ts
@@ -8,7 +8,7 @@ import { TransactionApiType, TransactionResponse, TransactionState } from '../..
 
 @Route('transaction')
 @Tags('transaction')
-@Security('bearerAuth')
+@Security('BearerAuth')
 export class TransactionController extends Controller {
   log: Logger
   db: Database

--- a/tsoa.json
+++ b/tsoa.json
@@ -1,9 +1,7 @@
 {
   "entryFile": "src/index.ts",
   "noImplicitAdditionalProperties": "throw-on-extras",
-  "controllerPathGlobs": [
-    "src/controllers/**/*.ts"
-  ],
+  "controllerPathGlobs": ["src/controllers/**/*.ts"],
   "multerOpts": {
     "limits": {
       "fileSize": 104857600
@@ -27,6 +25,17 @@
             "requestBody": {
               "required": true,
               "content": {
+                "multipart/form-data": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "type": "string",
+                        "format": "binary"
+                      }
+                    }
+                  }
+                },
                 "application/json": {
                   "schema": {
                     "anyOf": [
@@ -48,11 +57,7 @@
                   }
                 }
               }
-            },
-            "consumes": [
-              "multipart/form-data",
-              "application/json"
-            ]
+            }
           }
         },
         "/attachment/{id}": {

--- a/tsoa.json
+++ b/tsoa.json
@@ -11,7 +11,7 @@
     "outputDirectory": "src",
     "specVersion": 3,
     "securityDefinitions": {
-      "bearerAuth": {
+      "BearerAuth": {
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT"


### PR DESCRIPTION
`consumes` is invalid in OpenAPi `3.0` https://swagger.io/docs/specification/describing-request-body/
change security definition `bearerAuth` → `BearerAuth` so it matches the base security spec for OpenAPI merging