### PR TITLE
Bug - db status of failing transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/lib/chainNode.ts
+++ b/src/lib/chainNode.ts
@@ -159,13 +159,17 @@ export default class ChainNode {
           }
 
           if (status.isFinalized) {
-            transactionDbUpdate('finalised')
-
             const processRanEvent = result.events.find(({ event: { method } }) => method === 'ProcessRan')
             const data = processRanEvent?.event?.data as EventData
             const tokens = data?.outputs?.map((x) => x.toNumber())
 
-            tokens ? resolve(tokens) : reject(Error('No token IDs returned'))
+            if (tokens) {
+              transactionDbUpdate('finalised')
+              resolve(tokens)
+            } else {
+              transactionDbUpdate('failed')
+              reject(Error('No token IDs returned'))
+            }
             unsub()
           }
         })

--- a/src/lib/chainNode.ts
+++ b/src/lib/chainNode.ts
@@ -123,7 +123,7 @@ export default class ChainNode {
     this.logger.debug('Preparing Transaction inputs: %j outputs: %j', inputs, outputsAsMaps)
 
     await this.api.isReady
-    const extrinsic = await this.api.tx.utxoNFT.runProcess(process, inputs, outputsAsMaps)
+    const extrinsic = this.api.tx.utxoNFT.runProcess(process, inputs, outputsAsMaps)
     const account = this.keyring.addFromUri(this.userUri)
     const signed = await extrinsic.signAsync(account, { nonce: -1 })
     return signed

--- a/test/integration/onchain/chain.test.ts
+++ b/test/integration/onchain/chain.test.ts
@@ -40,6 +40,27 @@ describe('on-chain', function () {
     await cleanup()
   })
 
+  describe('chainNode', () => {
+    it('should set transaction as failed if dispatch error', async () => {
+      // use invalid process to cause a dispatch error
+      const invalidProcess = { id: 'invalid', version: 1 }
+      const extrinsic = await node.prepareRunProcess({ process: invalidProcess, inputs: [], outputs: [] })
+      const [transaction] = await db.insertTransaction({
+        api_type: 'capacity',
+        transaction_type: 'creation',
+        local_id: seededCapacityId,
+        state: 'submitted',
+        hash: extrinsic.hash.toHex(),
+      })
+
+      node.submitRunProcess(extrinsic, db.updateTransactionState(transaction.id))
+
+      // wait for dispatch error
+      const failedTransaction = await pollTransactionState(db, transaction.id, 'failed')
+      expect(failedTransaction.state).to.equal('failed')
+    })
+  })
+
   describe('capacity', () => {
     it('should create a capacity on-chain', async () => {
       const lastTokenId = await node.getLastTokenId()


### PR DESCRIPTION
Bug - Transactions are stored as finalised/inblock even when there is a dispatch error.

Fix - if there's a dispatchError, set transaction as failed and unsub. If the finalised event doesn't produce token IDs as expected, set transaction as failed.