### PR TITLE
Correctly encode indexed IPFS hashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/lib/chainNode.ts
+++ b/src/lib/chainNode.ts
@@ -8,6 +8,7 @@ import { TransactionState } from '../models/transaction'
 
 import type { Payload, Output, Metadata } from './payload'
 import { HEX } from '../models/strings'
+import { hexToBs58 } from '../utils/hex'
 
 const processRanTopic = blake2AsHex('utxoNFT.ProcessRan')
 
@@ -289,6 +290,11 @@ export default class ChainNode {
         if (valueKey === 'None' || valueKey === 'tokenId') {
           return [key, valueRaw]
         }
+
+        if (valueKey === 'file') {
+          return [key, hexToBs58(valueRaw)]
+        }
+
         const valueHex = valueRaw || '0x'
         const value = Buffer.from(valueHex.substring(2), 'hex').toString('utf8')
         return [key, value]

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,11 +1,7 @@
-import basex from 'base-x'
-
 import { Match2Payload, Match2Response } from '../models/match2'
 import { DemandPayload } from '../models/demand'
 import * as TokenType from '../models/tokenType'
-
-const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-const bs58 = basex(BASE58)
+import { bs58ToHex } from '../utils/hex'
 
 export interface Payload {
   process: { id: string; version: number }
@@ -25,11 +21,6 @@ export interface MetadataFile {
 
 export type Metadata = Record<string, { type: string; value: string | number }>
 
-const formatHash = (hash: string) => {
-  const decoded = Buffer.from(bs58.decode(hash))
-  return `0x${decoded.toString('hex').slice(4)}`
-}
-
 export const demandCreate = (demand: DemandPayload): Payload => ({
   process: { id: 'demand-create', version: 1 },
   inputs: [],
@@ -41,7 +32,7 @@ export const demandCreate = (demand: DemandPayload): Payload => ({
         type: { type: 'LITERAL', value: TokenType.DEMAND },
         state: { type: 'LITERAL', value: 'created' },
         subtype: { type: 'LITERAL', value: demand.subtype },
-        parameters: { type: 'FILE', value: formatHash(demand.ipfs_hash) },
+        parameters: { type: 'FILE', value: bs58ToHex(demand.ipfs_hash) },
       },
     },
   ],

--- a/src/utils/__tests__/hex.test.ts
+++ b/src/utils/__tests__/hex.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+import { bs58ToHex, hexToBs58 } from '../hex'
+
+describe('hex util', function () {
+  it('should convert bs58 to hex correctly', function () {
+    const hex = bs58ToHex('QmYvYwvD33prqdjdFKKA1xaqoJjCzYViCUxH9z7qMgBR6Q')
+    expect(hex).to.equal('0x9d441a0fe4fb942070f4d3014e2367496d4afc3bc9b983f1ac5b3813467a0c19')
+  })
+
+  it('should convert hex to bs58 correctly', function () {
+    const bs58 = hexToBs58('0x9d441a0fe4fb942070f4d3014e2367496d4afc3bc9b983f1ac5b3813467a0c19')
+    expect(bs58).to.equal('QmYvYwvD33prqdjdFKKA1xaqoJjCzYViCUxH9z7qMgBR6Q')
+  })
+})

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,0 +1,15 @@
+import basex from 'base-x'
+
+const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const bs58 = basex(BASE58)
+
+export const bs58ToHex = (hash: string) => {
+  const decoded = Buffer.from(bs58.decode(hash))
+  return `0x${decoded.toString('hex').slice(4)}` //remove 1220 prefix
+}
+
+export const hexToBs58 = (hex: string) => {
+  const stripped = hex.startsWith('0x') ? hex.slice(2) : hex
+  const buffer = Buffer.from(`1220${stripped}`, 'hex')
+  return bs58.encode(buffer)
+}


### PR DESCRIPTION
Bug:
IPFS hashes of files uploaded by other members were stored incorrectly, 1st row is correct (because it was uploaded by the local member) 2nd row is malformed:
![image](https://user-images.githubusercontent.com/40722025/236434001-43b2647f-aa96-4249-955b-88aedfcd89f7.png)

Fix:
Convert IPFS hashes received from the chain from `hex` to `bs58`

Proof:
Using `MemberA` API, get a `DemandA` made by `MemberB` (note the `owner` is the `Bob` address used by `MemberB`)
![image](https://user-images.githubusercontent.com/40722025/236433553-4e11d180-c046-4803-9897-ded6c5a65e32.png)

Using `parametersAttachmentId` from that demand we can successfully get the file:
![image](https://user-images.githubusercontent.com/40722025/236433753-57eaa682-5e5d-462b-8cc3-76d44c076f94.png)

