### PR TITLE
POST `match2/{id}/rejection` GET `match2/{id}/rejection` + GET `match2/{id}/rejection/{id}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ To clear chain and database state, delete the volumes e.g. `docker compose -f do
 
 ### Rejection paths
 
-The previous scenario covers a 'happy path' where every member accepts each step without comment. There are also routes for communicating when things have gone wrong.
+The previous scenario covers a 'happy path' where every member accepts each step without issue. There are also routes for communicating when something has gone wrong.
 
 #### Commenting on demands
 

--- a/README.md
+++ b/README.md
@@ -214,3 +214,15 @@ Note the meaning in the API of `demandA` and `demandB` are abstract and use-case
 11. Once the second member accepts, we have a successful match! The `match2` state changes to `acceptedFinal` and `demandA` + `demandB` state moves to `allocated`. These demands can no longer be used in a new `match2`.
 
 To clear chain and database state, delete the volumes e.g. `docker compose -f docker-compose-3-persona.yml down -v`.
+
+### Rejection paths
+
+The previous scenario covers a 'happy path' where every member accepts each step without comment. There are also routes for communicating when things have gone wrong.
+
+#### Commenting on demands
+
+At any time a `demandA` or `demandB` can be commented on by any member by `POST`ing a single attachment to [`POST /v1/demandA/{id}/comment`](http://localhost:8000/swagger/#/demandA/CreateDemandBCommentOnChain) or [`POST /v1/demandB/{id}/comment`](http://localhost:8000/swagger/#/demandB/CreateDemandBCommentOnChain). The attachment is a file that informs the owner of the demand about anything (e.g. an issue, correction) related to the demand. A demand can be commented on multiple times and it does not change the demand's state.
+
+#### Rejecting match2
+
+At any time after a `match2` is `proposed`, and before it reaches `acceptedFinal` state, any of its members can reject the `match2` using [`POST /v1/match2/{id}/rejection`](http://localhost:8000/swagger/#/match2/RejectMatch2OnChain). Once a `match2` is rejected, it is permanently closed.

--- a/docs/database.md
+++ b/docs/database.md
@@ -58,13 +58,13 @@ The following tables exist in the `matchmaker-api` database.
 
 ### `transaction`
 
-| column             | PostgreSQL type | nullable |       default        | description                                                  |
-| :----------------- | :-------------- | :------- | :------------------: | :----------------------------------------------------------- |
-| `id`               | `UUID`          | FALSE    | `uuid_generate_v4()` | Unique identifier for the `transaction`                      |
-| `local_id`         | `UUID`          | FALSE    |                      | The Match2 or Demand id of the transaction                   |
-| `api_type`         | `ENUM`          | FALSE    |                      | The entity of transaction (`match2`, `demand_a`, `demand_b`) |
-| `transaction_type` | `ENUM`          | FALSE    |                      | The transaction type (creation, proposal, accept)            |
-| `hash`             | `CHAR (64)`     | FALSE    |                      | The `hash` of the transaction extrinsic                      |
+| column             | PostgreSQL type | nullable |       default        | description                                                                     |
+| :----------------- | :-------------- | :------- | :------------------: | :------------------------------------------------------------------------------ |
+| `id`               | `UUID`          | FALSE    | `uuid_generate_v4()` | Unique identifier for the `transaction`                                         |
+| `local_id`         | `UUID`          | FALSE    |                      | The Match2 or Demand id of the transaction                                      |
+| `api_type`         | `ENUM`          | FALSE    |                      | The entity of transaction (`match2`, `demand_a`, `demand_b`)                    |
+| `transaction_type` | `ENUM`          | FALSE    |                      | The transaction type (`creation`, `proposal`, `accept`, `comment`, `rejection`) |
+| `hash`             | `CHAR (64)`     | FALSE    |                      | The `hash` of the transaction extrinsic                                         |
 
 #### Indexes
 
@@ -77,19 +77,19 @@ The following tables exist in the `matchmaker-api` database.
 
 #### Columns
 
-| column              | PostgreSQL type           | nullable |       default        | description                                                                            |
-| :------------------ | :------------------------ | :------- | :------------------: | :------------------------------------------------------------------------------------- |
-| `id`                | `UUID`                    | FALSE    | `uuid_generate_v4()` | Unique identifier for the `match2`                                                     |
-| `optimiser`         | `STRING (48)`             | FALSE    |          -           | Name of the optimiser                                                                  |
-| `member_a`          | `STRING (48)`             | FALSE    |          -           | Name of the first member                                                               |
-| `member_b`          | `STRING (48)`             | FALSE    |          -           | Name of the second member                                                              |
-| `state`             | `ENUM`                    | FALSE    |          -           | Current match state (`pending`, `proposed`, `acceptedA`, `acceptedB`, `acceptedFinal`) |
-| `latest_token_id`   | `INT`                     | TRUE     |          -           | Possible current token ID                                                              |
-| `original_token_id` | `INT`                     | TRUE     |          -           | Possible original token ID                                                             |
-| `demand_a_id`       | `UUID`                    | FALSE    |          -           | Unique identifier for the first demand                                                 |
-| `demand_b_id`       | `UUID`                    | FALSE    |          -           | Unique identifier for the second demand                                                |
-| `created_at`        | `Timestamp with timezone` | FALSE    |       `now()`        | When the row was first created                                                         |
-| `updated_at`        | `Timestamp with timezone` | FALSE    |       `now()`        | When the row was updated                                                               |
+| column              | PostgreSQL type           | nullable |       default        | description                                                                                        |
+| :------------------ | :------------------------ | :------- | :------------------: | :------------------------------------------------------------------------------------------------- |
+| `id`                | `UUID`                    | FALSE    | `uuid_generate_v4()` | Unique identifier for the `match2`                                                                 |
+| `optimiser`         | `STRING (48)`             | FALSE    |          -           | Name of the optimiser                                                                              |
+| `member_a`          | `STRING (48)`             | FALSE    |          -           | Name of the first member                                                                           |
+| `member_b`          | `STRING (48)`             | FALSE    |          -           | Name of the second member                                                                          |
+| `state`             | `ENUM`                    | FALSE    |          -           | Current match state (`pending`, `proposed`, `acceptedA`, `acceptedB`, `acceptedFinal`, `rejected`) |
+| `latest_token_id`   | `INT`                     | TRUE     |          -           | Possible current token ID                                                                          |
+| `original_token_id` | `INT`                     | TRUE     |          -           | Possible original token ID                                                                         |
+| `demand_a_id`       | `UUID`                    | FALSE    |          -           | Unique identifier for the first demand                                                             |
+| `demand_b_id`       | `UUID`                    | FALSE    |          -           | Unique identifier for the second demand                                                            |
+| `created_at`        | `Timestamp with timezone` | FALSE    |       `now()`        | When the row was first created                                                                     |
+| `updated_at`        | `Timestamp with timezone` | FALSE    |       `now()`        | When the row was updated                                                                           |
 
 #### Indexes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/v1/demandA/index.ts
+++ b/src/controllers/v1/demandA/index.ts
@@ -152,7 +152,7 @@ export class demandA extends Controller {
 
   /**
    * A Member creates a new demand for a demandA by referencing an uploaded parameters file.
-   * @summary Create a new demandA demand
+   * @summary Create a new demandA
    * @param parametersAttachmentId The attachment's identifier
    */
   @Post()
@@ -183,8 +183,8 @@ export class demandA extends Controller {
   }
 
   /**
-   * A member creates the demandA {demandAId} on-chain. The demandA is now viewable to other members.
-   * @summary Create a new demandA demand on-chain
+   * A member comments on a demandA {demandAId} on-chain.
+   * @summary Comment on a demandA on-chain
    * @param demandAId The demandA's identifier
    */
   @Post('{demandAId}/comment')
@@ -227,9 +227,9 @@ export class demandA extends Controller {
   }
 
   /**
-   * @summary Get a demandA creation transaction by ID
+   * @summary Get a demandA comment transaction by ID
    * @param demandAId The demandA's identifier
-   * @param creationId The demandA's creation ID
+   * @param creationId The demandA's comment ID
    */
   @Response<NotFound>(404, 'Item not found.')
   @SuccessResponse('200')
@@ -244,8 +244,8 @@ export class demandA extends Controller {
   }
 
   /**
-   * @summary Get all of a demandAB's creation transactions
-   * @param demandAId The demandAB's identifier
+   * @summary Get all of a demandA's comment transactions
+   * @param demandAId The demandA's identifier
    */
   @Response<NotFound>(404, 'Item not found.')
   @SuccessResponse('200')

--- a/src/controllers/v1/demandB/index.ts
+++ b/src/controllers/v1/demandB/index.ts
@@ -54,7 +54,7 @@ export class DemandBController extends Controller {
 
   /**
    * A Member creates a new demand for a demandB by referencing an uploaded parameters file.
-   * @summary Create a new demandB demand
+   * @summary Create a new demandB
    */
   @Post()
   @Response<BadRequest>(400, 'Request was invalid')
@@ -87,7 +87,7 @@ export class DemandBController extends Controller {
   }
 
   /**
-   * Returns the details of all demandB demands.
+   * Returns the details of all demandBs.
    * @summary List demandBs
    */
   @Get('/')
@@ -119,7 +119,7 @@ export class DemandBController extends Controller {
 
   /**
    * A member creates the demandB {demandBId} on-chain. The demandB is now viewable to other members.
-   * @summary Create a new demandB demand on-chain
+   * @summary Create a new demandB on-chain
    * @param demandBId The demandB's identifier
    */
   @Post('{demandBId}/creation')
@@ -189,8 +189,8 @@ export class DemandBController extends Controller {
   }
 
   /**
-   * A member creates the demandB {demandBId} on-chain. The demandB is now viewable to other members.
-   * @summary Create a new demandB demand on-chain
+   * A member comments on a demandB {demandBId} on-chain.
+   * @summary Comment on a demandB on-chain
    * @param demandBId The demandB's identifier
    */
   @Post('{demandBId}/comment')
@@ -233,9 +233,9 @@ export class DemandBController extends Controller {
   }
 
   /**
-   * @summary Get a demandB creation transaction by ID
+   * @summary Get a demandB comment transaction by ID
    * @param demandBId The demandB's identifier
-   * @param creationId The demandB's creation ID
+   * @param creationId The demandB's comment ID
    */
   @Response<NotFound>(404, 'Item not found.')
   @SuccessResponse('200')
@@ -250,8 +250,8 @@ export class DemandBController extends Controller {
   }
 
   /**
-   * @summary Get all of a demandAB's creation transactions
-   * @param demandBId The demandAB's identifier
+   * @summary Get all of a demandB's comment transactions
+   * @param demandBId The demandB's identifier
    */
   @Response<NotFound>(404, 'Item not found.')
   @SuccessResponse('200')

--- a/src/controllers/v1/match2/index.ts
+++ b/src/controllers/v1/match2/index.ts
@@ -18,10 +18,10 @@ import { logger } from '../../../lib/logger'
 import Database, { DemandRow, Match2Row } from '../../../lib/db'
 import { BadRequest, HttpResponse, NotFound } from '../../../lib/error-handler/index'
 import { getMemberByAddress, getMemberBySelf } from '../../../lib/services/identity'
-import { Match2Request, Match2Response } from '../../../models/match2'
+import { Match2Request, Match2Response, Match2State } from '../../../models/match2'
 import { DATE, UUID } from '../../../models/strings'
 import { TransactionResponse, TransactionType } from '../../../models/transaction'
-import { match2AcceptFinal, match2AcceptFirst, match2Propose } from '../../../lib/payload'
+import { match2AcceptFinal, match2AcceptFirst, match2Propose, match2Reject } from '../../../lib/payload'
 import { DemandSubtype } from '../../../models/demand'
 import ChainNode from '../../../lib/chainNode'
 import env from '../../../env'
@@ -299,6 +299,85 @@ export class Match2Controller extends Controller {
       transactionType: TransactionType
       updatedSince?: Date
     } = { localId: match2Id, transactionType: 'accept' }
+    if (updated_since) {
+      query.updatedSince = parseDateParam(updated_since)
+    }
+
+    const [match2] = await this.db.getMatch2(match2Id)
+    if (!match2) throw new NotFound('match2')
+
+    return await this.db.getTransactionsByLocalId(query)
+  }
+
+  /**
+   * A member rejects a match2 {match2Id} on-chain.
+   * @summary Reject a match2 on-chain
+   * @param match2Id The match2's identifier
+   */
+  @Post('{match2Id}/rejection')
+  @Response<NotFound>(404, 'Item not found')
+  @Response<BadRequest>(400, 'Request was invalid')
+  @SuccessResponse('200')
+  public async rejectMatch2OnChain(@Path() match2Id: UUID): Promise<TransactionResponse> {
+    const [match2] = await this.db.getMatch2(match2Id)
+    if (!match2) throw new NotFound('match2')
+
+    const roles = [match2.memberA, match2.memberB, match2.optimiser]
+    const { address: selfAddress } = await getMemberBySelf()
+    if (!roles.includes(selfAddress)) throw new BadRequest(`You do not have a role on the match2`)
+
+    const rejectableStates: Match2State[] = ['proposed', 'acceptedA', 'acceptedB']
+    if (!rejectableStates.includes(match2.state))
+      throw new BadRequest(`Match2 state must be one of: ${rejectableStates.join(', ')}`)
+
+    const extrinsic = await this.node.prepareRunProcess(match2Reject(match2))
+
+    const [transaction] = await this.db.insertTransaction({
+      transaction_type: 'rejection',
+      api_type: 'match2',
+      local_id: match2Id,
+      state: 'submitted',
+      hash: extrinsic.hash.toHex(),
+    })
+
+    this.node.submitRunProcess(extrinsic, this.db.updateTransactionState(transaction.id))
+    return transaction
+  }
+
+  /**
+   * @summary Get a match2 rejection transaction by ID
+   * @param match2Id The match2's identifier
+   * @param rejectionId The match2's rejection ID
+   */
+  @Response<NotFound>(404, 'Item not found.')
+  @SuccessResponse('200')
+  @Get('{match2Id}/rejection/{rejectionId}')
+  public async getMatch2Rejection(@Path() match2Id: UUID, rejectionId: UUID): Promise<TransactionResponse> {
+    const [match2] = await this.db.getMatch2(match2Id)
+    if (!match2) throw new NotFound('match2')
+
+    const [rejection] = await this.db.getTransaction(rejectionId)
+    if (!rejection) throw new NotFound('rejection')
+
+    return rejection
+  }
+
+  /**
+   * @summary Get all of a match2's rejection transactions
+   * @param match2Id The match2's identifier
+   */
+  @Response<NotFound>(404, 'Item not found.')
+  @SuccessResponse('200')
+  @Get('{match2Id}/rejection')
+  public async getMatch2Rejections(
+    @Path() match2Id: UUID,
+    @Query() updated_since?: DATE
+  ): Promise<TransactionResponse[]> {
+    const query: {
+      localId: UUID
+      transactionType: TransactionType
+      updatedSince?: Date
+    } = { localId: match2Id, transactionType: 'rejection' }
     if (updated_since) {
       query.updatedSince = parseDateParam(updated_since)
     }

--- a/src/lib/db/migrations/20230511093955_match2-rejection.ts
+++ b/src/lib/db/migrations/20230511093955_match2-rejection.ts
@@ -1,0 +1,11 @@
+import { Knex } from 'knex'
+
+export const up = async (knex: Knex): Promise<void> => {
+  await knex.raw('ALTER TYPE "transaction_type" ADD VALUE \'rejection\'')
+  await knex.raw('ALTER TYPE "match2_state" ADD VALUE \'rejected\'')
+}
+
+export const down = async (knex: Knex): Promise<void> => {
+  await knex.raw('ALTER TYPE "transaction_type" REMOVE VALUE \'rejection\'')
+  await knex.raw('ALTER TYPE "match2_state" REMOVE VALUE \'rejection\'')
+}

--- a/src/lib/indexer/__tests__/eventProcessor.test.ts
+++ b/src/lib/indexer/__tests__/eventProcessor.test.ts
@@ -225,4 +225,24 @@ describe('eventProcessor', function () {
       })
     })
   })
+
+  describe('match2-reject', function () {
+    it('should error with version != 1', function () {
+      let error: Error | null = null
+      try {
+        eventProcessors['match2-reject'](0, null, 'alice', [], [])
+      } catch (err) {
+        error = err instanceof Error ? err : null
+      }
+      expect(error).instanceOf(Error)
+    })
+
+    it('should update the state of the match2 to match output', function () {
+      const result = eventProcessors['match2-reject'](1, null, 'alice', [{ id: 1, localId: 'id_1' }], [])
+
+      expect(result).to.deep.equal({
+        matches: new Map([['id_1', { type: 'update', id: 'id_1', state: 'rejected' }]]),
+      })
+    })
+  })
 })

--- a/src/lib/indexer/__tests__/fixtures/eventProcessor.ts
+++ b/src/lib/indexer/__tests__/fixtures/eventProcessor.ts
@@ -8,4 +8,5 @@ export const withMockEventProcessors: (result?: ChangeSet) => EventProcessors = 
   'match2-propose': sinon.stub().returns(result),
   'match2-accept': sinon.stub().returns(result),
   'match2-acceptFinal': sinon.stub().returns(result),
+  'match2-reject': sinon.stub().returns(result),
 })

--- a/src/lib/indexer/changeSet.ts
+++ b/src/lib/indexer/changeSet.ts
@@ -58,7 +58,7 @@ export type MatchRecord =
       id: string
       state: string
       original_token_id?: number
-      latest_token_id: number
+      latest_token_id?: number
     }
 
 export type AttachmentRecord = {

--- a/src/lib/indexer/eventProcessor.ts
+++ b/src/lib/indexer/eventProcessor.ts
@@ -10,6 +10,7 @@ const processNames = [
   'match2-accept',
   'match2-acceptFinal',
   'demand-comment',
+  'match2-reject',
 ] as const
 type PROCESSES_TUPLE = typeof processNames
 type PROCESSES = PROCESSES_TUPLE[number]
@@ -213,6 +214,26 @@ const DefaultEventProcessors: EventProcessors = {
       ]),
       matches: new Map([
         [matchLocalId, { type: 'update', id: matchLocalId, latest_token_id: matchId, state: 'acceptedFinal' }],
+      ]),
+    }
+  },
+  'match2-reject': (version, _transaction, _sender, inputs, _outputs) => {
+    if (version !== 1) {
+      throw new Error(`Incompatible version ${version} for match2-reject process`)
+    }
+
+    const localId = inputs[0].localId
+
+    return {
+      matches: new Map([
+        [
+          localId,
+          {
+            id: localId,
+            type: 'update',
+            state: 'rejected',
+          },
+        ],
       ]),
     }
   },

--- a/src/lib/indexer/eventProcessor.ts
+++ b/src/lib/indexer/eventProcessor.ts
@@ -217,6 +217,7 @@ const DefaultEventProcessors: EventProcessors = {
       ]),
     }
   },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   'match2-reject': (version, _transaction, _sender, inputs, _outputs) => {
     if (version !== 1) {
       throw new Error(`Incompatible version ${version} for match2-reject process`)

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -152,3 +152,9 @@ export const match2AcceptFinal = (match2: Match2Row, demandA: DemandRow, demandB
     },
   ],
 })
+
+export const match2Reject = (match2: Match2Row): Payload => ({
+  process: { id: 'match2-reject', version: 1 },
+  inputs: [match2.latestTokenId as number],
+  outputs: [],
+})

--- a/src/models/match2.ts
+++ b/src/models/match2.ts
@@ -3,7 +3,7 @@ import { DATE, UUID } from './strings'
 /**
  * The possible states of a Match2
  */
-export type Match2State = 'pending' | 'proposed' | 'acceptedA' | 'acceptedB' | 'acceptedFinal'
+export type Match2State = 'pending' | 'proposed' | 'acceptedA' | 'acceptedB' | 'acceptedFinal' | 'rejected'
 
 /**
  * A Match2 returned by the API

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -25,4 +25,4 @@ export type TransactionApiType = 'match2' | 'demand_a' | 'demand_b'
 /**
  * Transaction type - matches the endpoint that initiates the transaction
  */
-export type TransactionType = 'creation' | 'proposal' | 'accept' | 'comment'
+export type TransactionType = 'creation' | 'proposal' | 'accept' | 'comment' | 'rejection'

--- a/test/integration/offchain/match2.test.ts
+++ b/test/integration/offchain/match2.test.ts
@@ -25,6 +25,8 @@ import {
   seededMatch2NotAcceptableBoth,
   seededAcceptTransactionId,
   seededDemandAWithTokenId,
+  seededRejectionTransactionId,
+  seededMatch2NotInRoles,
 } from '../../seeds'
 
 import { selfAlias, withIdentitySelfMock } from '../../helper/mock'
@@ -162,6 +164,44 @@ describe('match2', () => {
       const { status, body } = await get(
         app,
         `/v1/match2/${seededMatch2Id}/accept?updated_since=2023-01-01T00:00:00.000Z`
+      )
+      expect(status).to.equal(200)
+      expect(body).to.deep.equal([])
+    })
+
+    it('it should get a rejection transaction', async () => {
+      const { status, body } = await get(app, `/v1/match2/${seededMatch2Id}/rejection/${seededRejectionTransactionId}`)
+      expect(status).to.equal(200)
+      expect(body).to.deep.equal({
+        id: seededRejectionTransactionId,
+        apiType: 'match2',
+        transactionType: 'rejection',
+        localId: seededMatch2Id,
+        state: 'submitted',
+        submittedAt: exampleDate,
+        updatedAt: exampleDate,
+      })
+    })
+
+    it('it should get all rejection transactions', async () => {
+      const { status, body } = await get(app, `/v1/match2/${seededMatch2Id}/rejection`)
+      expect(status).to.equal(200)
+      expect(body).to.be.an('array')
+      expect(body.find(({ id }: { id: string }) => id === seededRejectionTransactionId)).to.deep.equal({
+        id: seededRejectionTransactionId,
+        apiType: 'match2',
+        transactionType: 'rejection',
+        localId: seededMatch2Id,
+        state: 'submitted',
+        submittedAt: exampleDate,
+        updatedAt: exampleDate,
+      })
+    })
+
+    it('should filter rejection transactions based on updated date', async () => {
+      const { status, body } = await get(
+        app,
+        `/v1/match2/${seededMatch2Id}/rejection?updated_since=2023-01-01T00:00:00.000Z`
       )
       expect(status).to.equal(200)
       expect(body).to.deep.equal([])
@@ -346,6 +386,51 @@ describe('match2', () => {
       const response = await get(app, `/v1/match2/${seededMatch2Id}/accept/${nonExistentId}`)
       expect(response.status).to.equal(404)
       expect(response.body).to.equal('accept not found')
+    })
+
+    it('rejection of match2 at incorrect state - 400', async () => {
+      const response = await post(app, `/v1/match2/${seededMatch2AcceptedFinal}/rejection`, {})
+      expect(response.status).to.equal(400)
+      expect(response.body).to.equal(`Match2 state must be one of: proposed, acceptedA, acceptedB`)
+    })
+
+    it('rejection of match2 submitter not in roles - 400', async () => {
+      const response = await post(app, `/v1/match2/${seededMatch2NotInRoles}/rejection`, {})
+      expect(response.status).to.equal(400)
+      expect(response.body).to.equal(`You do not have a role on the match2`)
+    })
+
+    it('non-existent match2 id when rejection - 404', async () => {
+      const response = await get(app, `/v1/match2/${nonExistentId}/rejection`)
+      expect(response.status).to.equal(404)
+      expect(response.body).to.equal('match2 not found')
+    })
+
+    it('non-existent match2 when listing rejections - 404', async () => {
+      const response = await get(app, `/v1/match2/${nonExistentId}/rejection`)
+      expect(response.status).to.equal(404)
+      expect(response.body).to.equal('match2 not found')
+    })
+
+    it('list rejections with invalid updatedSince - 422', async () => {
+      const { status, body } = await get(app, `/v1/match2/${seededMatch2AcceptedA}/rejection?updated_since=foo`)
+      expect(status).to.equal(422)
+      expect(body).to.contain({
+        name: 'ValidateError',
+        message: 'Validation failed',
+      })
+    })
+
+    it('non-existent match2 when getting a rejection - 404', async () => {
+      const response = await get(app, `/v1/match2/${nonExistentId}/rejection/${seededRejectionTransactionId}`)
+      expect(response.status).to.equal(404)
+      expect(response.body).to.equal('match2 not found')
+    })
+
+    it('non-existent transaction when getting a rejection - 404', async () => {
+      const response = await get(app, `/v1/match2/${seededMatch2Id}/rejection/${nonExistentId}`)
+      expect(response.status).to.equal(404)
+      expect(response.body).to.equal('rejection not found')
     })
   })
 })

--- a/test/integration/offchain/transaction.test.ts
+++ b/test/integration/offchain/transaction.test.ts
@@ -96,9 +96,9 @@ describe('transaction', () => {
   it('returns all transactions', async () => {
     const { status, body } = await get(app, '/v1/transaction')
 
-    // TODO create a fixtures
+    // TODO create fixture
     expect(status).to.equal(200)
-    expect(body.length).to.equal(9)
+    expect(body).to.be.an('array')
     expect(body).to.deep.include.members([
       {
         id: '1f3af974-7d4d-40b4-86a5-94a2241265cb',

--- a/test/integration/onchain/match2.test.ts
+++ b/test/integration/onchain/match2.test.ts
@@ -166,13 +166,48 @@ describe('on-chain', function () {
       expect(match2AcceptFinal.originalTokenId).to.equal(match2OriginalId)
     })
 
-    it('should reject a match2 on-chain', async () => {
+    it('should reject a proposed match2 on-chain', async () => {
       // propose
       const proposal = await post(context.app, `/v1/match2/${match2LocalId}/proposal`, {})
       expect(proposal.status).to.equal(201)
 
       // wait for block to finalise
       await pollTransactionState(db, proposal.body.id, 'finalised')
+
+      const [maybeMatch2] = await db.getMatch2(match2LocalId)
+      const match2 = maybeMatch2 as Match2Row
+      const match2LatestTokenId = match2.latestTokenId
+
+      // reject match2
+      const rejection = await post(context.app, `/v1/match2/${match2LocalId}/rejection`, {})
+      expect(rejection.status).to.equal(200)
+
+      // wait for block to finalise
+      await pollTransactionState(db, rejection.body.id, 'finalised')
+
+      // check local entities update with token id
+      const [maybeMatch2Rejected] = await db.getMatch2(match2LocalId)
+      const match2Rejected = maybeMatch2Rejected as Match2Row
+      expect(match2Rejected.state).to.equal('rejected')
+
+      // no output token means latest token ID remains the same
+      expect(match2Rejected.latestTokenId).to.equal(match2LatestTokenId)
+    })
+
+    it('should reject an acceptedA match2 on-chain', async () => {
+      // propose
+      const proposal = await post(context.app, `/v1/match2/${match2LocalId}/proposal`, {})
+      expect(proposal.status).to.equal(201)
+
+      // wait for block to finalise
+      await pollTransactionState(db, proposal.body.id, 'finalised')
+
+      // acceptA
+      const acceptA = await post(context.app, `/v1/match2/${match2LocalId}/accept`, {})
+      expect(acceptA.status).to.equal(201)
+
+      // wait for block to finalise
+      await pollTransactionState(db, acceptA.body.id, 'finalised')
 
       const [maybeMatch2] = await db.getMatch2(match2LocalId)
       const match2 = maybeMatch2 as Match2Row

--- a/test/seeds/index.ts
+++ b/test/seeds/index.ts
@@ -24,6 +24,7 @@ export const seededDemandBCommentTransactionId = '07e0511a-6041-40df-9d5b-2e5966
 export const seededDemandBCommentTransactionId2 = '3e1b64cc-62e4-417c-b73e-e4f28336012b'
 export const seededProposalTransactionId = '8a5343dc-88a3-4b61-b156-330d52f506f8'
 export const seededAcceptTransactionId = 'd8eb8a94-222b-4481-b315-1dcbf2e07079'
+export const seededRejectionTransactionId = 'd8eb8a94-222b-4481-b315-1dcbf2e07078'
 export const seededDemandAId = 'ae350c28-f696-4e95-8467-d00507dfcc39'
 
 export const seededMatch2Id = 'f960e4a1-6182-4dd3-8ac2-6f3fad995551'
@@ -41,6 +42,7 @@ export const seededMatch2AcceptedFinal = '85a50fd9-f20f-4a61-a7e4-3ad49b7c3f21'
 export const seededMatch2NotAcceptableA = '46d7dbe8-aaef-472e-af9f-ecdd2681d3a5'
 export const seededMatch2NotAcceptableB = '097d3905-72aa-4517-85d2-0091d26fceac'
 export const seededMatch2NotAcceptableBoth = '619fb8ca-4dd9-4843-8c7a-9d9c9474784d'
+export const seededMatch2NotInRoles = '619fb8ca-4dd9-4843-8c7a-9d9c9474784e'
 
 const seededDemandANotOwnedId = 'c88908aa-a2a6-48df-a698-572aa30159c0'
 const seededDemandBNotOwnedId = 'b21f865e-f4e9-4ae2-8944-de691e9eb4d9'
@@ -228,6 +230,19 @@ export const seed = async () => {
       id: seededAcceptTransactionId,
       api_type: 'match2',
       transaction_type: 'accept',
+      local_id: seededMatch2Id,
+      state: 'submitted',
+      created_at: exampleDate,
+      updated_at: exampleDate,
+      hash: transactionHash,
+    },
+  ])
+
+  await db.transaction().insert([
+    {
+      id: seededRejectionTransactionId,
+      api_type: 'match2',
+      transaction_type: 'rejection',
       local_id: seededMatch2Id,
       state: 'submitted',
       created_at: exampleDate,
@@ -435,6 +450,22 @@ export const seed = async () => {
       id: seededMatch2NotAcceptableBoth,
       state: 'acceptedB',
       optimiser: selfAddress,
+      member_a: notSelfAddress,
+      member_b: notSelfAddress,
+      demand_a_id: seededDemandANotOwnedId,
+      demand_b_id: seededDemandBNotOwnedId,
+      latest_token_id: seededMatch2TokenId,
+      original_token_id: seededMatch2TokenId,
+      created_at: exampleDate,
+      updated_at: exampleDate,
+    },
+  ])
+
+  await db.match2().insert([
+    {
+      id: seededMatch2NotInRoles,
+      state: 'acceptedB',
+      optimiser: notSelfAddress,
       member_a: notSelfAddress,
       member_b: notSelfAddress,
       demand_a_id: seededDemandANotOwnedId,


### PR DESCRIPTION
Add `match2-reject` and associated transaction routes.
Happy and sad path tests for new routes
Includes `eventProcessor` handling for indexing `match2-reject` processes
DB docs and README scenario update