### PR TITLE
Bug/fix comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/controllers/v1/_common/demand.ts
+++ b/src/controllers/v1/_common/demand.ts
@@ -154,7 +154,7 @@ export class DemandController extends Controller {
     })
 
     await this.db.insertDemandComment({
-      id: transaction.id,
+      transaction_id: transaction.id,
       state: 'pending',
       owner: selfAddress,
       demand: demandId,

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -250,14 +250,14 @@ export default class Database {
     return this.db().demand_comment().insert(comment).returning('*')
   }
 
-  updateDemandComment = async (id: UUID, comment: object) => {
+  updateDemandCommentForTransaction = async (transactionId: UUID, comment: object) => {
     return this.db()
       .demand_comment()
       .update({
         ...comment,
         updated_at: this.client.fn.now(),
       })
-      .where({ id })
+      .where({ transaction_id: transactionId })
       .returning('*')
   }
 

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -228,11 +228,11 @@ export default class Database {
     return query
   }
 
-  getDemandComment = async (commentId: UUID): Promise<[DemandCommentRow] | []> => {
+  getDemandCommentForTransaction = async (transactionId: UUID): Promise<[DemandCommentRow] | []> => {
     const [result] = await this.db()
       .demand_comment()
       .select(demandCommentsColumns)
-      .where({ id: commentId })
+      .where({ transaction_id: transactionId })
       .orderBy('created_at', 'asc')
 
     return [result]

--- a/src/lib/db/migrations/20230516140922_demand-comment-rekey.ts
+++ b/src/lib/db/migrations/20230516140922_demand-comment-rekey.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex'
+
+export const up = async (knex: Knex): Promise<void> => {
+  await knex.schema.alterTable('demand_comment', (def) => {
+    def.dropPrimary()
+  })
+
+  await knex.schema.alterTable('demand_comment', (def) => {
+    def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).alter()
+    def.uuid('transaction_id').nullable()
+    def.dropForeign(['id', 'demand'], 'demand-comment-transaction-id-demand')
+  })
+
+  await knex.schema.alterTable('demand_comment', (def) => {
+    def.primary(['id'])
+    def
+      .foreign(['transaction_id', 'demand'], 'demand-comment-transaction-id-demand')
+      .references(['id', 'local_id'])
+      .inTable('transaction')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE')
+  })
+
+  await knex('demand_comment').update({
+    transaction_id: knex.raw('??', ['id']),
+  })
+}
+
+export const down = async (knex: Knex): Promise<void> => {
+  await knex.schema.alterTable('demand_comment', (def) => {
+    def.dropPrimary()
+    def.dropForeign(['transaction_id', 'demand'], 'demand-comment-transaction-id-demand')
+  })
+
+  await knex.schema.alterTable('demand_comment', (def) => {
+    def
+      .foreign(['id', 'demand'], 'demand-comment-transaction-id-demand')
+      .references(['id', 'local_id'])
+      .inTable('transaction')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE')
+    def.dropColumn('transaction_id')
+    def.uuid('id').notNullable().defaultTo(null).alter()
+  })
+
+  await knex.schema.alterTable('demand_comment', (def) => {
+    def.primary(['id'])
+  })
+}

--- a/src/lib/indexer/__tests__/eventProcessor.test.ts
+++ b/src/lib/indexer/__tests__/eventProcessor.test.ts
@@ -95,7 +95,7 @@ describe('eventProcessor', function () {
 
       expect(result).to.deep.equal({
         demands: new Map([['42', { type: 'update', id: '42', state: 'allocated', latest_token_id: 2 }]]),
-        demandComments: new Map([['10', { type: 'update', id: '10', state: 'created' }]]),
+        demandComments: new Map([['10', { type: 'update', transaction_id: '10', state: 'created' }]]),
       })
     })
 

--- a/src/lib/indexer/changeSet.ts
+++ b/src/lib/indexer/changeSet.ts
@@ -36,7 +36,7 @@ export type DemandCommentRecord =
     }
   | {
       type: 'update'
-      id: string
+      transaction_id: string
       state: 'created'
     }
 

--- a/src/lib/indexer/eventProcessor.ts
+++ b/src/lib/indexer/eventProcessor.ts
@@ -99,7 +99,7 @@ const DefaultEventProcessors: EventProcessors = {
             transaction.id,
             {
               type: 'update',
-              id: transaction.id,
+              transaction_id: transaction.id,
               state: 'created',
             },
           ],

--- a/src/lib/indexer/index.ts
+++ b/src/lib/indexer/index.ts
@@ -228,14 +228,12 @@ export default class Indexer {
 
       if (changeSet.demandComments) {
         for (const [, comment] of changeSet.demandComments) {
-          const { type, ...record } = comment
-          switch (type) {
-            case 'insert':
-              await db.insertDemandComment(record)
-              break
-            case 'update':
-              await db.updateDemandComment(record.id, record)
-              break
+          if (comment.type === 'insert') {
+            const { type, ...record } = comment
+            await db.insertDemandComment(record)
+          } else {
+            const { type, ...record } = comment
+            await db.updateDemandCommentForTransaction(record.transaction_id, record)
           }
         }
       }

--- a/test/integration/onchain/demandA.test.ts
+++ b/test/integration/onchain/demandA.test.ts
@@ -91,7 +91,7 @@ describe('on-chain', function () {
       expect(demandA.latestTokenId).to.equal(lastTokenId + 2)
       expect(demandA.originalTokenId).to.equal(lastTokenId + 1)
 
-      const [maybeComment] = await db.getDemandComment(commentResponse.body.id)
+      const [maybeComment] = await db.getDemandCommentForTransaction(commentResponse.body.id)
       if (!maybeComment) {
         expect.fail('Expected comment to be in db')
       }

--- a/test/integration/onchain/demandB.test.ts
+++ b/test/integration/onchain/demandB.test.ts
@@ -84,7 +84,7 @@ describe('on-chain', function () {
       expect(demandB.latestTokenId).to.equal(lastTokenId + 2)
       expect(demandB.originalTokenId).to.equal(lastTokenId + 1)
 
-      const [maybeComment] = await db.getDemandComment(commentResponse.body.id)
+      const [maybeComment] = await db.getDemandCommentForTransaction(commentResponse.body.id)
       if (!maybeComment) {
         expect.fail('Expected comment to be in db')
       }


### PR DESCRIPTION
Fixes an issue with the db during the comment workflow. At the moment we require that the `id` of the `demand_comment` row be equal to an `id` in the `transaction` table. this works if we submit the transaction but an observer doesn't have this transaction. Therefore the insert fails.

The fix is to add a new column `transaction_id` to the `demand_comment` table and when we update update based on this. The column is then nullable so if it's a straigth insert the foreign key is a no-op.