### PR TITLE
added identityStatus files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.2.46",
+  "version": "1.2.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "1.2.46",
+      "version": "1.2.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.2.47",
+  "version": "1.2.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "1.2.47",
+      "version": "1.2.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.2.46",
+  "version": "1.2.47",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.2.47",
+  "version": "1.2.48",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/lib/service-watcher/identityStatus.ts
+++ b/src/lib/service-watcher/identityStatus.ts
@@ -1,0 +1,16 @@
+import { startStatusHandler } from './statusPoll'
+import env from '../../env'
+import IdentityClass from '../services/identity'
+
+const { WATCHER_POLL_PERIOD_MS, WATCHER_TIMEOUT_MS } = env
+
+const identityClass = new IdentityClass()
+
+const startIdentityStatus = () =>
+  startStatusHandler({
+    getStatus: identityClass.getStatus.bind(identityClass),
+    pollingPeriodMs: WATCHER_POLL_PERIOD_MS,
+    serviceTimeoutMs: WATCHER_TIMEOUT_MS,
+  })
+
+export default startIdentityStatus

--- a/src/lib/service-watcher/index.ts
+++ b/src/lib/service-watcher/index.ts
@@ -1,6 +1,7 @@
 import { singleton } from 'tsyringe'
 import startApiStatus from './apiStatus'
 import startIpfsStatus from './ipfsStatus'
+import startIdentityStatus from './identityStatus'
 import { buildCombinedHandler, SERVICE_STATE, Status } from './statusPoll'
 
 @singleton()
@@ -25,9 +26,14 @@ export class ServiceWatcher {
     close: () => void
   }> => {
     const handlers = new Map()
-    const [apiStatus, ipfsStatus] = await Promise.all([startApiStatus(), startIpfsStatus()])
+    const [apiStatus, ipfsStatus, identityStatus] = await Promise.all([
+      startApiStatus(),
+      startIpfsStatus(),
+      startIdentityStatus(),
+    ])
     handlers.set('api', apiStatus)
     handlers.set('ipfs', ipfsStatus)
+    handlers.set('identity', identityStatus)
 
     return buildCombinedHandler(handlers)
   }

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -2,7 +2,7 @@ import { NotFound, HttpResponse } from '../error-handler'
 import env from '../../env'
 import { Status, serviceState } from '../service-watcher/statusPoll'
 
-const URL_PREFIX = `http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}/v1`
+const URL_PREFIX = `http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}`
 
 export default class IdentityClass {
   constructor() {}
@@ -11,7 +11,7 @@ export default class IdentityClass {
     try {
       const res = await getHealth()
       if (res) {
-        if (res.version.length < 1) {
+        if (!res.version.match(/\d+.\d+.\d+/)) {
           return {
             status: serviceState.DOWN,
             detail: {
@@ -39,7 +39,7 @@ export default class IdentityClass {
 }
 // TODO : refactor into the class above. Ticket: https://digicatapult.atlassian.net/browse/L3-182
 const getMemberByAlias = async (alias: string) => {
-  const res = await fetch(`${URL_PREFIX}/members/${encodeURIComponent(alias)}`)
+  const res = await fetch(`${URL_PREFIX}/v1/members/${encodeURIComponent(alias)}`)
 
   if (res.ok) {
     return await res.json()
@@ -53,7 +53,7 @@ const getMemberByAlias = async (alias: string) => {
 }
 
 const getHealth = async () => {
-  const res = await fetch(`http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}/health`)
+  const res = await fetch(`${URL_PREFIX}/health`)
 
   if (res.ok) {
     return await res.json()
@@ -63,7 +63,7 @@ const getHealth = async () => {
 }
 
 const getMemberBySelf = async () => {
-  const res = await fetch(`${URL_PREFIX}/self`)
+  const res = await fetch(`${URL_PREFIX}/v1/self`)
 
   if (res.ok) {
     return await res.json()

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -1,7 +1,58 @@
 import { NotFound, HttpResponse } from '../error-handler'
 import env from '../../env'
+export const serviceState = {
+  UP: 'up',
+  DOWN: 'down',
+  ERROR: 'error',
+} as const
+type serviceStateType = typeof serviceState
+export type SERVICE_STATE = serviceStateType['UP' | 'DOWN' | 'ERROR']
+export type Status = {
+  status: SERVICE_STATE
+  detail: Record<string, unknown> | null
+}
 
 const URL_PREFIX = `http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}/v1`
+
+export default class IdentityClass {
+  constructor() {}
+
+  getStatus = async (): Promise<Status> => {
+    try {
+      const res = await getMemberBySelf()
+      console.log(res)
+      if (res) {
+        if (res.address.length < 1) {
+          return {
+            status: serviceState.DOWN,
+            detail: {
+              message: 'Error getting status from Identity service',
+            },
+          }
+        }
+        return {
+          status: serviceState.UP,
+          detail: {
+            version: 'some version',
+          },
+        }
+      }
+      return {
+        status: serviceState.DOWN,
+        detail: {
+          message: 'Error getting status from Identity service',
+        },
+      }
+    } catch (err) {
+      return {
+        status: serviceState.DOWN,
+        detail: {
+          message: 'Error getting status from Identity service',
+        },
+      }
+    }
+  }
+}
 
 const getMemberByAlias = async (alias: string) => {
   const res = await fetch(`${URL_PREFIX}/members/${encodeURIComponent(alias)}`)

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -1,17 +1,6 @@
 import { NotFound, HttpResponse } from '../error-handler'
 import env from '../../env'
-
-type serviceStateType = typeof serviceState
-export type SERVICE_STATE = serviceStateType['UP' | 'DOWN' | 'ERROR']
-export type Status = {
-  status: SERVICE_STATE
-  detail: Record<string, unknown> | null
-}
-export const serviceState = {
-  UP: 'up',
-  DOWN: 'down',
-  ERROR: 'error',
-} as const
+import { Status, serviceState } from '../service-watcher/statusPoll'
 
 const URL_PREFIX = `http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}/v1`
 

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -11,7 +11,6 @@ export default class IdentityClass {
     try {
       const res = await getHealth()
       if (res) {
-        // console.log(res.version)
         if (res.version.length < 1) {
           return {
             status: serviceState.DOWN,
@@ -38,7 +37,7 @@ export default class IdentityClass {
     }
   }
 }
-
+// TODO : refactor into the class above. Ticket: https://digicatapult.atlassian.net/browse/L3-182
 const getMemberByAlias = async (alias: string) => {
   const res = await fetch(`${URL_PREFIX}/members/${encodeURIComponent(alias)}`)
 

--- a/src/lib/services/identity.ts
+++ b/src/lib/services/identity.ts
@@ -1,16 +1,17 @@
 import { NotFound, HttpResponse } from '../error-handler'
 import env from '../../env'
-export const serviceState = {
-  UP: 'up',
-  DOWN: 'down',
-  ERROR: 'error',
-} as const
+
 type serviceStateType = typeof serviceState
 export type SERVICE_STATE = serviceStateType['UP' | 'DOWN' | 'ERROR']
 export type Status = {
   status: SERVICE_STATE
   detail: Record<string, unknown> | null
 }
+export const serviceState = {
+  UP: 'up',
+  DOWN: 'down',
+  ERROR: 'error',
+} as const
 
 const URL_PREFIX = `http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}/v1`
 
@@ -19,10 +20,10 @@ export default class IdentityClass {
 
   getStatus = async (): Promise<Status> => {
     try {
-      const res = await getMemberBySelf()
-      console.log(res)
+      const res = await getHealth()
       if (res) {
-        if (res.address.length < 1) {
+        // console.log(res.version)
+        if (res.version.length < 1) {
           return {
             status: serviceState.DOWN,
             detail: {
@@ -33,16 +34,11 @@ export default class IdentityClass {
         return {
           status: serviceState.UP,
           detail: {
-            version: 'some version',
+            version: res.version,
           },
         }
       }
-      return {
-        status: serviceState.DOWN,
-        detail: {
-          message: 'Error getting status from Identity service',
-        },
-      }
+      throw new Error()
     } catch (err) {
       return {
         status: serviceState.DOWN,
@@ -63,6 +59,16 @@ const getMemberByAlias = async (alias: string) => {
 
   if (res.status === 404) {
     throw new NotFound(`identity: ${alias}`)
+  }
+
+  throw new HttpResponse({})
+}
+
+const getHealth = async () => {
+  const res = await fetch(`http://${env.IDENTITY_SERVICE_HOST}:${env.IDENTITY_SERVICE_PORT}/health`)
+
+  if (res.ok) {
+    return await res.json()
   }
 
   throw new HttpResponse({})

--- a/test/helper/healthHelper.ts
+++ b/test/helper/healthHelper.ts
@@ -1,5 +1,5 @@
 export const responses = {
-  ok: (dscpRuntimeVersion: number, ipfsVersion: string) => ({
+  ok: (dscpRuntimeVersion: number, ipfsVersion: string, identityVersion: string) => ({
     code: 200,
     body: {
       status: 'ok',
@@ -25,6 +25,12 @@ export const responses = {
           detail: {
             version: ipfsVersion,
             peerCount: 1,
+          },
+        },
+        identity: {
+          status: 'ok',
+          detail: {
+            version: identityVersion,
           },
         },
       },
@@ -55,6 +61,12 @@ export const responses = {
           status: 'down',
           detail: {
             message: 'Error getting status from IPFS node',
+          },
+        },
+        identity: {
+          status: 'ok',
+          detail: {
+            version: 'some version',
           },
         },
       },

--- a/test/helper/healthHelper.ts
+++ b/test/helper/healthHelper.ts
@@ -36,7 +36,7 @@ export const responses = {
       },
     },
   }),
-  ipfsDown: (dscpRuntimeVersion: number) => ({
+  ipfsDown: (dscpRuntimeVersion: number, identityVersion: string) => ({
     code: 503,
     body: {
       status: 'down',
@@ -66,7 +66,7 @@ export const responses = {
         identity: {
           status: 'ok',
           detail: {
-            version: 'some version',
+            version: identityVersion,
           },
         },
       },

--- a/test/integration/offchain/healthcheck.test.ts
+++ b/test/integration/offchain/healthcheck.test.ts
@@ -15,6 +15,9 @@ const getSpecVersion = (actualResult: any) => {
 const getIpfsVersion = (actualResult: any) => {
   return actualResult?._body?.details?.ipfs?.detail?.version
 }
+const getIdentityVersion = (actualResult: any) => {
+  return actualResult?._body?.detail?.version
+}
 
 describe('health check', () => {
   describe('happy path', function () {
@@ -34,7 +37,12 @@ describe('health check', () => {
 
     it('health check', async function () {
       const actualResult = await get(app, '/health')
-      const response = healthResponses.ok(getSpecVersion(actualResult), getIpfsVersion(actualResult))
+      console.log(actualResult.body.details.identity)
+      const response = healthResponses.ok(
+        getSpecVersion(actualResult),
+        getIpfsVersion(actualResult),
+        getIdentityVersion(actualResult)
+      )
       expect(actualResult.status).to.equal(response.code)
       expect(actualResult.body).to.deep.equal(response.body)
     })

--- a/test/integration/offchain/healthcheck.test.ts
+++ b/test/integration/offchain/healthcheck.test.ts
@@ -37,7 +37,6 @@ describe('health check', () => {
 
     it('health check', async function () {
       const actualResult = await get(app, '/health')
-      // console.log(actualResult.body.details.identity)
       const response = healthResponses.ok(
         getSpecVersion(actualResult),
         getIpfsVersion(actualResult),

--- a/test/integration/offchain/healthcheck.test.ts
+++ b/test/integration/offchain/healthcheck.test.ts
@@ -16,7 +16,7 @@ const getIpfsVersion = (actualResult: any) => {
   return actualResult?._body?.details?.ipfs?.detail?.version
 }
 const getIdentityVersion = (actualResult: any) => {
-  return actualResult?._body?.detail?.version
+  return actualResult?._body?.details?.identity?.detail?.version
 }
 
 describe('health check', () => {
@@ -37,7 +37,7 @@ describe('health check', () => {
 
     it('health check', async function () {
       const actualResult = await get(app, '/health')
-      console.log(actualResult.body.details.identity)
+      // console.log(actualResult.body.details.identity)
       const response = healthResponses.ok(
         getSpecVersion(actualResult),
         getIpfsVersion(actualResult),
@@ -65,7 +65,7 @@ describe('health check', () => {
 
     it('service down', async function () {
       const actualResult = await get(app, '/health')
-      const response = healthResponses.ipfsDown(getSpecVersion(actualResult))
+      const response = healthResponses.ipfsDown(getSpecVersion(actualResult), getIdentityVersion(actualResult))
       expect(actualResult.status).to.equal(response.code)
       expect(actualResult.body).to.deep.equal(response.body)
     })


### PR DESCRIPTION
Hello, 
please have a look and let me know how I should proceed. 
1. for identity.ts - can I move remaining methods to the IdentityClass? - if i do so, should I move URL_PREFIX to the constructor so that I always pass host and port every time a new instance of the class is made(if so, is it correct that I will always instatiate it with env.IDENTITY_SERVICE_HOST and env.IDENTITY_SERVICE_PORT - if so then I don't need to take in any parameters anyway and just have it as a private variable)? (I am asking because ipfs.ts and chainNode.ts are structured this way) (I have a question about how the environmental variables work in the 3-person yml - but having a call would be better) 
2. in identity.ts you'll notice I don't know how to get the identity version - any tips will be appreciated 
3. in healthHelper.ts - would I want to add a case for identityDown? 

4. question off-topic but are tests run against the 3-ppl yml? or just against the docker-compose.yml? - because it looks like some of my tests pass against one and some agains the other (once again if someone is willing to jump on a call, it'd be appreciated :))