### PR TITLE
Bug/l3 215

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "scripts": {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,7 +1,5 @@
 import knex, { Knex } from 'knex'
-import type { Logger } from 'pino'
 
-import { logger } from '../logger'
 import { pgConfig } from './knexfile'
 import { DemandState, DemandSubtype } from '../../models/demand'
 import { HEX, UUID } from '../../models/strings'
@@ -146,17 +144,12 @@ function restore0x(input: ProcessedBlockTrimmed): ProcessedBlock {
 const clientSingleton: Knex = knex(pgConfig)
 
 export default class Database {
-  private client: Knex
-  private log: Logger
-  public db: () => Models<() => QueryBuilder>
+  private db: () => Models<() => QueryBuilder>
 
-  constructor() {
-    this.log = logger
-    this.client = clientSingleton
+  constructor(private client: Knex = clientSingleton) {
     const models = tablesList.reduce((acc, name) => {
-      this.log.debug(`initializing ${name} db model`)
       return {
-        [name]: () => this.client(name),
+        [name]: () => client(name),
         ...acc,
       }
     }, {}) as Models<() => QueryBuilder>
@@ -406,10 +399,7 @@ export default class Database {
 
   withTransaction = (update: (db: Database) => Promise<void>) => {
     return this.client.transaction(async (trx) => {
-      const decorated: Database = {
-        ...this,
-        client: trx,
-      }
+      const decorated = new Database(trx)
       await update(decorated)
     })
   }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -144,7 +144,7 @@ function restore0x(input: ProcessedBlockTrimmed): ProcessedBlock {
 const clientSingleton: Knex = knex(pgConfig)
 
 export default class Database {
-  private db: () => Models<() => QueryBuilder>
+  public db: () => Models<() => QueryBuilder>
 
   constructor(private client: Knex = clientSingleton) {
     const models = tablesList.reduce((acc, name) => {


### PR DESCRIPTION
This fixes a bug that appeared in https://github.com/digicatapult/dscp-matchmaker-api/pull/46. Essentially database transaction don't work because the `this` binding isn't changed in the `models` functions when recreating. This change refactors things to avoid the use of `this`
