### PR TITLE
Add volume for 3 persona IPFS

### DIFF
--- a/docker-compose-3-persona.yml
+++ b/docker-compose-3-persona.yml
@@ -338,6 +338,8 @@ services:
       - 8080:8080
       - 5001:5001
     networks: ['ipfs']
+    volumes:
+      - ipfs:/data/ipfs
 
 volumes:
   member-a-matchmaker-api-storage:


### PR DESCRIPTION
Add a persistent volume for IPFS when demoing with 3 personas. Means attachment storage is persistent between sessions (unless the volume is cleared)