### PR TITLE
v2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-matchmaker-api",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-matchmaker-api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "An OpenAPI Matchmaking API service for DSCP",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Release https://github.com/digicatapult/dscp-matchmaker-api/actions/runs/7486606292 failed because the version wasn't bumped. This bumps the version